### PR TITLE
fix: corrige atualização de produto

### DIFF
--- a/src/main/java/com/avalanches/core/application/usecases/ProdutoUseCase.java
+++ b/src/main/java/com/avalanches/core/application/usecases/ProdutoUseCase.java
@@ -78,7 +78,7 @@ public class ProdutoUseCase implements ProdutoUseCasePort {
                 produtoRepository.cadastrarImagemProduto(produto.id, imagem.id);
             }
         }
-        produtoRepository.cadastrar(produto);
+        produtoRepository.atualizar(produto);
     }
 
     @Override


### PR DESCRIPTION
Foi modificado o método de atualização do produto para utilizar o 'cadastrar' na mudança de linguagem ubíqua, o correto é 'atualizar'.